### PR TITLE
Add a logarithmic implementation of at

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,19 @@
 #include "type_list.hpp"
 
 int main() {
+    static_assert(std::is_same_v<tl::first_t<tl::type_list<char>>, char>, "Oh no!");
+    static_assert(std::is_same_v<tl::first_t<tl::type_list<bool, char>>, bool>, "Oh no!");
+    static_assert(std::is_same_v<tl::first_t<tl::type_list<void, bool, char>>, void>, "Oh no!");
+
+    static_assert(std::is_same_v<tl::last_t<tl::type_list<char>>, char>, "Oh no!");
+    static_assert(std::is_same_v<tl::last_t<tl::type_list<char, bool>>, bool>, "Oh no!");
+    static_assert(std::is_same_v<tl::last_t<tl::type_list<char, bool, void>>, void>, "Oh no!");
+
+    // Should fail:
+    // static_assert(std::is_same_v<tl::first_t<tl::type_list<>>, void>, "Oh no!");
+    // static_assert(std::is_same_v<tl::last_t<tl::type_list<>>, void>, "Oh no!");
+
+
     using list_t = tl::type_list<char, bool, void>;
 
     static_assert(std::is_same_v<char, typename tl::at<0, list_t>::type>, "Oh no!");
@@ -33,4 +46,51 @@ int main() {
     // Should fail:
     // tl::concat_t<int> X;
     // tl::concat_t<int, list_t> Y;
+
+    using void256 = tl::type_list<
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void,
+        void, void, void, void, void, void, void, void, void, void, void, void, void, void, void, void
+    >;
+    using void4096 = tl::concat_t<
+        void256, void256, void256, void256, void256, void256, void256, void256,
+        void256, void256, void256, void256, void256, void256, void256, void256
+    >;
+    static_assert(std::is_same_v<void, tl::at_t<void4096::size - 1, void4096>>, "Oh no!");
+    static_assert(std::is_same_v<void, tl::last_t<void4096>>, "Oh no!");
+
+    // This starts to get slow (~5s):
+    // using void65536 = tl::concat_t<
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256,
+    //     void256, void256, void256, void256, void256, void256, void256, void256
+    // >;
+    // static_assert(std::is_same_v<void, tl::at_t<void65536::size - 1, void65536>>, "Oh no!");
+    // static_assert(std::is_same_v<void, tl::last_t<void65536>>, "Oh no!");
 }


### PR DESCRIPTION
After trying it by hand for a while, I gave up and used one of the techniques described in https://ldionne.com/2015/11/29/efficient-parameter-pack-indexing/ for getting the nth element of a parameter pack. The trick uses pack expansions and std::index_sequences, which probably use a constant-time compiler intrinsic. The difference in compile-time is significant: we went from ~15s to get the last element of void4096 (and needing to increase the compiler's template recursion limit) to ~5s to get the last element of void65536 (with the default recursion limit).

Other minor additions were adding the `size` static constexpr member of type_list, which I think is fine as a member rather than an external "trait-style" struct. Also added were some first/last convenience types.